### PR TITLE
Ammendment to the Impyrial Book of Law

### DIFF
--- a/app/assets/style.css
+++ b/app/assets/style.css
@@ -18,6 +18,7 @@
 
 .book-of-law {
   background: beige;
+  border: .1rem solid black;
 }
 .law {
   font-family: 'Times New Roman', Times, serif
@@ -28,9 +29,13 @@
   font-style: italic;
 }
 .law-body{
-  background: whitesmoke;
+  background: beige;
+  border: .1rem solid black;
+  border-radius: 5px;
   font-family: 'Times New Roman', Times, serif;
   font-size: .8em;
+  overflow-y: scroll;
+  max-height: 250px;
 }
 
 #footer {

--- a/app/assets/style.css
+++ b/app/assets/style.css
@@ -29,12 +29,8 @@
 }
 .law-body{
   background: beige;
-  border: .1rem solid black;
-  border-radius: 5px;
   font-family: 'Times New Roman', Times, serif;
   font-size: .8em;
-  overflow-y: scroll;
-  max-height: 250px;
 }
 
 #footer {

--- a/app/assets/style.css
+++ b/app/assets/style.css
@@ -18,7 +18,6 @@
 
 .book-of-law {
   background: beige;
-  border: .1rem solid black;
 }
 .law {
   font-family: 'Times New Roman', Times, serif

--- a/app/assets/style.css
+++ b/app/assets/style.css
@@ -16,6 +16,23 @@
   padding-right: 13px;
 }
 
+.book-of-law {
+  background: beige;
+}
+.law {
+  font-family: 'Times New Roman', Times, serif
+}
+.law-author{
+  margin: 0;
+  font-size: .6em;
+  font-style: italic;
+}
+.law-body{
+  background: whitesmoke;
+  font-family: 'Times New Roman', Times, serif;
+  font-size: .8em;
+}
+
 #footer {
   border-top: 1px #999 dotted;
 }

--- a/app/controllers/lore/index.js
+++ b/app/controllers/lore/index.js
@@ -3,6 +3,7 @@
 const express = require('express');
 const repo = require$('config/github/repo');
 const api = require$('lib/github-api');
+const md = require("marked").setOptions({gfm: true, sanitize:true});
 
 const router = express.Router();
 
@@ -28,7 +29,7 @@ function list() {
         result.data = result.data
           .filter(pr => pr.merged_at)
           .sort(sortByMergeDate);
-        res.render('lore/list', { ...result}); })
+        res.render('lore/list', { ...result, md}); })
       .catch(err => { 
         next(err); });
 }

--- a/app/controllers/lore/index.js
+++ b/app/controllers/lore/index.js
@@ -28,7 +28,7 @@ function list() {
         result.data = result.data
           .filter(pr => pr.merged_at)
           .sort(sortByMergeDate);
-        res.render('lore/list', {state, ...result}); })
+        res.render('lore/list', { ...result}); })
       .catch(err => { 
         next(err); });
 }

--- a/app/controllers/lore/index.js
+++ b/app/controllers/lore/index.js
@@ -6,15 +6,28 @@ const api = require$('lib/github-api');
 
 const router = express.Router();
 
-function list(state) {
+function sortByMergeDate(left,right){
+  const aMergeDate = Date.parse(a.merged_at);
+  const bMergeDate = Date.parse(b.merged_at);
+  if( aMergeDate < bMergeDate)
+    return -1;
+  else if (aMergeDate > bMergeDate)
+    return 1;
+  else 
+    return 0; 
+}
+
+function list() {
   return (req, res, next) => 
     api.pullRequests.getAll({
         repo: repo.repo,
         owner: repo.owner,
-        state
+        state: 'closed'
       })
       .then(result => { 
-        result.data = result.data.filter(pr => pr.merged_at);
+        result.data = result.data
+          .filter(pr => pr.merged_at)
+          .sort(sortByMergeDate);
         res.render('lore/list', {state, ...result}); })
       .catch(err => { 
         next(err); });
@@ -34,7 +47,7 @@ function item() {
   };
 }
 
-router.get('/', list('closed'));
+router.get('/', list());
 router.get('/:number', item());
 
 module.exports = router;

--- a/app/controllers/lore/index.js
+++ b/app/controllers/lore/index.js
@@ -6,7 +6,7 @@ const api = require$('lib/github-api');
 
 const router = express.Router();
 
-function sortByMergeDate(left,right){
+function sortByMergeDate(a,b){
   const aMergeDate = Date.parse(a.merged_at);
   const bMergeDate = Date.parse(b.merged_at);
   if( aMergeDate < bMergeDate)

--- a/app/views/lore/list.pug
+++ b/app/views/lore/list.pug
@@ -1,7 +1,7 @@
 extends ../_layout.pug
 
 block vars
-  - const title = 'Book of Law'
+  - const title = 'The Impyrial Book of Law'
 
 block content
   h2.c-heading.u-xlarge
@@ -25,6 +25,7 @@ block content
             if item.body
               .u-letter-box-medium 
                 code.c-code.c-code--multiline.u-window-box-medium= item.body
+            hr
                 
     else
       li No Laws have been passed.

--- a/app/views/lore/list.pug
+++ b/app/views/lore/list.pug
@@ -1,7 +1,7 @@
 extends ../_layout.pug
 
 block vars
-  - const title = state + ' pull requests'
+  - const title = 'Book of Law'
 
 block content
   h2.c-heading.u-xlarge

--- a/app/views/lore/list.pug
+++ b/app/views/lore/list.pug
@@ -4,28 +4,29 @@ block vars
   - const title = 'The Impyrial Book of Law'
 
 block content
-  h2.c-heading.u-xlarge
-    :feather-icon(size='xlarge') git-pull-request
-    | The Impyrial Book of Law
-  ol.book-of-law
-    each item in data
-      li
-        div.law
-          h3.c-heading.u-large.law-title= item.title
-            span.c-text--quiet
-              a(href=item.html_url
-              target='_blank'
-              title='View on GitHub').c-link.x-link--ext.u-pillar-box-small
-              :feather-icon(size='large') github
-            if item.user
-              p.c-text--mono.law-author authored by:&#32;
-                a(href=item.user.html_url
-                target='_target').x-link--ext= item.user.login
+  div.book-of-law
+    h2.c-heading.u-xlarge
+      :feather-icon(size='xlarge') git-pull-request
+      | The Impyrial Book of Law
+    ol
+      each item in data
+        li
+          div.law
+            h3.c-heading.u-large.law-title= item.title
+              span.c-text--quiet
+                a(href=item.html_url
+                target='_blank'
+                title='View on GitHub').c-link.x-link--ext.u-pillar-box-small
+                :feather-icon(size='large') github
+              if item.user
+                p.c-text--mono.law-author authored by:&#32;
+                  a(href=item.user.html_url
+                  target='_target').x-link--ext= item.user.login
 
-            if item.body
-              .u-letter-box-medium
-                code.c-code.c-code--multiline.u-window-box-medium.law-body!= md(item.body)
-            hr
-                
-    else
-      li No Laws have been passed.
+              if item.body
+                .u-letter-box-medium
+                  code.c-code.c-code--multiline.u-window-box-medium.law-body!= md(item.body)
+              hr
+                  
+      else
+        li No Laws have been passed.

--- a/app/views/lore/list.pug
+++ b/app/views/lore/list.pug
@@ -25,7 +25,7 @@ block content
 
               if item.body
                 .u-letter-box-medium
-                  code.c-code.c-code--multiline.u-window-box-medium.law-body!= md(item.body)
+                  u-window-box-medium.law-body!= md(item.body)
               hr
                   
       else

--- a/app/views/lore/list.pug
+++ b/app/views/lore/list.pug
@@ -4,28 +4,28 @@ block vars
   - const title = 'The Impyrial Book of Law'
 
 block content
-    h2.c-heading.u-xlarge
-      :feather-icon(size='xlarge') git-pull-request
-      | The Impyrial Book of Law
-    ol.book-of-law
-      each item in data
-        li
-          div.law
-            h3.c-heading.u-large.law-title= item.title
-              span.c-text--quiet
-                a(href=item.html_url
-                target='_blank'
-                title='View on GitHub').c-link.x-link--ext.u-pillar-box-small
-                :feather-icon(size='large') github
-              if item.user
-                p.c-text--mono.law-author authored by:&#32;
-                  a(href=item.user.html_url
-                  target='_target').x-link--ext= item.user.login
+  h2.c-heading.u-xlarge
+    :feather-icon(size='xlarge') git-pull-request
+    | The Impyrial Book of Law
+  ol.book-of-law
+    each item in data
+      li
+        div.law
+          h3.c-heading.u-large.law-title= item.title
+            span.c-text--quiet
+              a(href=item.html_url
+              target='_blank'
+              title='View on GitHub').c-link.x-link--ext.u-pillar-box-small
+              :feather-icon(size='large') github
+            if item.user
+              p.c-text--mono.law-author authored by:&#32;
+                a(href=item.user.html_url
+                target='_target').x-link--ext= item.user.login
 
-              if item.body
-                .u-letter-box-medium
-                  code.c-code.c-code--multiline.u-window-box-medium.law-body = item.body
-              hr
+            if item.body
+              .u-letter-box-medium
+                code.c-code.c-code--multiline.u-window-box-medium.law-body!= md(item.body)
+            hr
                 
     else
       li No Laws have been passed.

--- a/app/views/lore/list.pug
+++ b/app/views/lore/list.pug
@@ -4,28 +4,28 @@ block vars
   - const title = 'The Impyrial Book of Law'
 
 block content
-  h2.c-heading.u-xlarge
-    :feather-icon(size='xlarge') git-pull-request
-    | The Impyrial Book of Law
-  ul
-    each item in data
-      li
-        div
-          h3.c-heading.u-large= item.title
-            span.c-text--quiet &#32;##{item.number}
-              a(href=item.html_url
-              target='_blank'
-              title='View on GitHub').c-link.x-link--ext.u-pillar-box-small
-              :feather-icon(size='large') github
-            if item.user
-              p.c-text--mono authored by:&#32;
-                a(href=item.user.html_url
-                target='_target').x-link--ext= item.user.login
+    h2.c-heading.u-xlarge
+      :feather-icon(size='xlarge') git-pull-request
+      | The Impyrial Book of Law
+    ol.book-of-law
+      each item in data
+        li
+          div.law
+            h3.c-heading.u-large.law-title= item.title
+              span.c-text--quiet
+                a(href=item.html_url
+                target='_blank'
+                title='View on GitHub').c-link.x-link--ext.u-pillar-box-small
+                :feather-icon(size='large') github
+              if item.user
+                p.c-text--mono.law-author authored by:&#32;
+                  a(href=item.user.html_url
+                  target='_target').x-link--ext= item.user.login
 
-            if item.body
-              .u-letter-box-medium 
-                code.c-code.c-code--multiline.u-window-box-medium= item.body
-            hr
+              if item.body
+                .u-letter-box-medium
+                  code.c-code.c-code--multiline.u-window-box-medium.law-body = item.body
+              hr
                 
     else
       li No Laws have been passed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -836,6 +836,11 @@
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
+    "marked": {
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "express": "^4.16.3",
     "feather-icons": "^4.7.0",
     "hoek": "^5.0.3",
+    "marked": "^0.3.19",
     "pug": "^2.0.3",
     "request": "^2.85.0",
     "request-promise": "^4.2.2",


### PR DESCRIPTION
The Book of Law, which displays for all to see the laws of the Impyr ought display laws in a relevant 
order. Since Laws passed inherit their function and their power from those in the past, 
elder laws should be introduced prior to their children.

__Amendment: Organizing the Book of Law__
1. Therefore, the Impyrial Book of Law shall be reorganized so that elder laws shall precede the younger.
2. Further, scribes shall be commissioned to improve the visual aspect of the venerable Impyrial Book of Law, in order to maintain the honor due to this prestigious tome.
 * As part of the scribe's work, they shall be tasked with properly casting the existing laws a more regal light, respecting the language in which the content was originally cast.