### PR TITLE
Isolation of the Lore Master

### DIFF
--- a/app/controllers/lore/index.js
+++ b/app/controllers/lore/index.js
@@ -3,7 +3,7 @@
 const express = require('express');
 const repo = require$('config/github/repo');
 const api = require$('lib/github-api');
-const md = require("marked").setOptions({gfm: true, sanitize:true});
+const md = require("../../lib/helpers/markdown-renderer");
 
 const router = express.Router();
 

--- a/app/controllers/pulls/index.js
+++ b/app/controllers/pulls/index.js
@@ -3,6 +3,7 @@
 const express = require('express');
 const repo = require$('config/github/repo');
 const api = require$('lib/github-api');
+const md = require("../../lib/helpers/markdown-renderer");
 
 const router = express.Router();
 
@@ -26,7 +27,7 @@ function item() {
         repo: repo.repo,
         owner: repo.owner,
       })
-      .then(result => { res.render('pulls/item', {number, ...result}); })
+      .then(result => { res.render('pulls/item', {number, ...result,md}); })
       .catch(err => { next(err); });
   };
 }

--- a/app/lib/helpers/markdown-renderer.js
+++ b/app/lib/helpers/markdown-renderer.js
@@ -1,0 +1,3 @@
+const md = require("marked").setOptions({gfm: true, sanitize:true});
+
+module.exports = md;

--- a/app/test/markdown-renderer.js
+++ b/app/test/markdown-renderer.js
@@ -1,0 +1,18 @@
+const expect = require('expect.js');
+const md = require('../lib/helpers/markdown-renderer');
+
+describe('Markdown Renderer', ()=>{
+    describe('Given a dangerous markdown string',()=>{
+        const codelikeString = "function(){console.log(\'badthings\')}();";
+        const dangerousString = `__good-string__ *<script>${codelikeString}</script>*`;
+        describe('When the renderer parses the dangerous string',()=>{
+            let result;
+            beforeEach(()=>{
+                result = md(dangerousString);
+            });
+            it('should scrub the dangerous html elements out of the input', ()=>{
+                 expect(result).not.to.contain(codelikeString);
+            });
+        });
+    });
+});

--- a/app/views/pulls/item.pug
+++ b/app/views/pulls/item.pug
@@ -15,7 +15,7 @@ block content
       :feather-icon(size='large') github
 
   .u-letter-box-medium 
-    code.c-code.c-code--multiline.u-window-box-medium= data.body
+    u-window-box-medium!= md(data.body)
 
     if data.user
       p.c-text--mono created by:&#32;

--- a/package-lock.json
+++ b/package-lock.json
@@ -453,6 +453,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "expect.js": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
+      "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s="
+    },
     "express": {
       "version": "4.16.3",
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@octokit/rest": "^15.2.6",
     "body-parser": "^1.18.2",
+    "expect.js": "^0.3.1",
     "express": "^4.16.3",
     "feather-icons": "^4.7.0",
     "hoek": "^5.0.3",


### PR DESCRIPTION
__Introductions__
Upon completion of the [Impyrial Book of Law](https://github.com/impyrio/archon-fountainhead/pull/13), the LoreMaster responsible for the visual aspect of the ancient tongue of the Law was accused of sedition. It is the view of the Council, that such accusation ought not be taken lightly.

__Decision__
Therefore, the LoreMaster in question shall be sequestered, that his grand work for the state might not be interrupted. He shall be given protection in order to preserve his person and to protect the mind of the state and her citizenry from the fearful assault originally brought by the accusation of sedition.

__Addendum the First:__
In an effort to lessen his harsh sentence, the LoreMaster has been awarded the additional task of properly setting the tongue of the law for proposed bills. The Council believes this additional labour will help to ease the hours of repose that will otherwise be imposed on the isolated LoreMaster. Long live the benevolent council.